### PR TITLE
fixup issue about krnln_fnToTime

### DIFF
--- a/krnln/krnln_ToTime.cpp
+++ b/krnln/krnln_ToTime.cpp
@@ -305,8 +305,6 @@ LIBAPI(void, krnln_ToTime)
 		}
 		break;
 	case SDT_DATE_TIME:
-	case SDT_DOUBLE:
-	case SDT_INT64:
 		break;
 	default:
 		ArgInf.m_double = -657434;//100Äê1ÔÂ1ÈÕ


### PR DESCRIPTION
 **result of `krnln_fnToTime`  function is different with origin krnln when argument type is SDT_DOUBLE or SDT_INT64**
- fixup this issue

> IDE version is 5.5.